### PR TITLE
Added BundleIdentifier

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,6 @@
 {
 	"BundleType": "Application",
+	"BundleIdentifier": "boilthefrog",
 	"AppIcon": {
 		"18x18": "frog-icon.png"
 	},


### PR DESCRIPTION
The BundleIdentifier attribute in manifest.json is required for Spotify to recognize and load the app.
